### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/mdlew/cf-workers-status-page-typescript/security/code-scanning/2](https://github.com/mdlew/cf-workers-status-page-typescript/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required. Based on the workflow's steps:
- The `actions/checkout` action requires `contents: read` to check out the repository.
- The `cloudflare/wrangler-action` may require additional permissions, such as `contents: read` and possibly `deployments: write` for deployment purposes.

We will start with `contents: read` and add any additional permissions explicitly if required by the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
